### PR TITLE
Add match-index feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Substitution syntax: added `$:&` and `$;&` to generate the match's index from the left and right, respectively. `<>[]` modifiers can be (ab)used for some off-by-one shenanigans.
+
 ## 1.1.1
 
 This version switches from .NET Framework to .NET Core.

--- a/Retina/Retina/Replace/Nodes/DynamicElement.cs
+++ b/Retina/Retina/Replace/Nodes/DynamicElement.cs
@@ -9,9 +9,9 @@ namespace Retina.Replace.Nodes
     public class DynamicElement : Node
     {
         public Node Child { get; set; }
-        private bool CyclicMatches;
+        private readonly bool CyclicMatches;
 
-        private History History;
+        private readonly History History;
 
         public DynamicElement(Node child, History history, bool cyclicMatches)
         {

--- a/Retina/Retina/Replace/Parser.cs
+++ b/Retina/Retina/Replace/Parser.cs
@@ -70,7 +70,7 @@ namespace Retina.Replace
                   (
                     (?<numbered>       # $n are numbered groups.
                       [<>[\]]?         # Pull the value from an adjacent separator or match.
-                      [#?]?            # Capture count or random capture.
+                      [#:;?]?          # Generic capture modifiers.
                       (?:\d+|&)        # & is an alias for 0.
                     )
                   |

--- a/Retina/Retina/Replace/Parser.cs
+++ b/Retina/Retina/Replace/Parser.cs
@@ -16,12 +16,12 @@ namespace Retina.Replace
             public ParserError(string message, Exception innerException) : base(message, innerException) { }
         }
 
-        private bool CyclicMatches;
+        private readonly bool CyclicMatches;
 
         private List<Token> Tokens;
         private int Current;
 
-        private History History;
+        private readonly History History;
 
         public Parser(History history)
         {

--- a/Retina/Retina/Stages/AtomicStage.cs
+++ b/Retina/Retina/Stages/AtomicStage.cs
@@ -24,8 +24,8 @@ namespace Retina.Stages
         private int PatternIndex;
 
         protected History History;
-        private bool RegisterWithHistory;
-        private int HistoryIndex;
+        private readonly bool RegisterWithHistory;
+        private readonly int HistoryIndex;
         
         protected AtomicStage(Config config, History history, bool registerByDefault) : base(config) {
             History = history;
@@ -203,8 +203,7 @@ namespace Retina.Stages
             if (Config.SingleRandomMatch && Matches.Count > 0)
             {
                 var chosenMatch = Matches[Random.RNG.Next(Matches.Count)];
-                Matches = new List<MatchContext>();
-                Matches.Add(chosenMatch);
+                Matches = new List<MatchContext> { chosenMatch };
             }
         }
 

--- a/Retina/RetinaTest/ReplacerTest.cs
+++ b/Retina/RetinaTest/ReplacerTest.cs
@@ -220,6 +220,45 @@ namespace RetinaTest
         }
 
         [TestMethod]
+        public void TestMatchIndex()
+        {
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$:0" }, TestCases = { { "123,321,123,321", "0,1,2,3" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$:&" }, TestCases = { { "123,321,123,321", "0,1,2,3" } } });
+
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$;0" }, TestCases = { { "123,321,123,321", "3,2,1,0" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$;&" }, TestCases = { { "123,321,123,321", "3,2,1,0" } } });
+        }
+
+        [TestMethod]
+        public void TestCumulativeCaptureCount()
+        {
+            AssertProgram(new TestSuite { Sources = { "(.)+", "#$:1" }, TestCases = { { "abcd\ndef", "#4\n#7" } } });
+            AssertProgram(new TestSuite { Sources = { "(..)+", "#$:1" }, TestCases = { { "abcd\ndef", "#2\n#3f" } } });
+            AssertProgram(new TestSuite { Sources = { "()(.)*", "$:2" }, TestCases = { { "abcd\ndef", "44\n77" } } });
+            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "$:1" }, TestCases = { { "aaabbcabbb", "5c9" } } });
+            AssertProgram(new TestSuite { Sources = { "(.)+", "#$;1" }, TestCases = { { "abcd\ndef", "#7\n#3" } } });
+            AssertProgram(new TestSuite { Sources = { "(..)+", "#$;1" }, TestCases = { { "abcd\ndef", "#3\n#1f" } } });
+            AssertProgram(new TestSuite { Sources = { "()(.)*", "$;2" }, TestCases = { { "abcd\ndef", "73\n30" } } });
+            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "$;1" }, TestCases = { { "aaabbcabbb", "9c5" } } });
+
+            // Curly braces should also work:
+            AssertProgram(new TestSuite { Sources = { "(.)+", "#${:1}" }, TestCases = { { "abcd\ndef", "#4\n#7" } } });
+            AssertProgram(new TestSuite { Sources = { "()(.)*", "${:2}" }, TestCases = { { "abcd\ndef", "40\n70" } } });
+            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "${:1}${:01}${:001}" }, TestCases = { { "aaabbcabbb", "555c999" } } });
+            AssertProgram(new TestSuite { Sources = { "(?<foo>a)+(?<bar>b)+", "${:foo}${:bar}" }, TestCases = { { "aaabbcabbb", "32c45" } } });
+            AssertProgram(new TestSuite { Sources = { "(.)+", "#${;1}" }, TestCases = { { "abcd\ndef", "#7\n#3" } } });
+            AssertProgram(new TestSuite { Sources = { "()(.)*", "${;2}" }, TestCases = { { "abcd\ndef", "73\n30" } } });
+            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "${;1}${;01}${;001}" }, TestCases = { { "aaabbcabbb", "999c444" } } });
+            AssertProgram(new TestSuite { Sources = { "(?<foo>a)+(?<bar>b)+", "${;foo}${;bar}" }, TestCases = { { "aaabbcabbb", "45c13" } } });
+
+            // $# not followed by a valid group should be removed.
+            AssertProgram(new TestSuite { Sources = { "(.)+", "$:2${:2}$:$:}" }, TestCases = { { "abcd", "$:$:}" } } });
+            AssertProgram(new TestSuite { Sources = { "(?<a>.)+", "$:a${:b}$:{" }, TestCases = { { "abcd", "$:a$:{" } } });
+            AssertProgram(new TestSuite { Sources = { "(.)+", "$:2${:2}$:$:}" }, TestCases = { { "abcd", "$;$;}" } } });
+            AssertProgram(new TestSuite { Sources = { "(?<a>.)+", "$:a${:b}$:{" }, TestCases = { { "abcd", "$;a$;{" } } });
+        }
+
+        [TestMethod]
         public void TestRandomCapture()
         {
             AssertRandomProgram(new RandomTestSuite
@@ -234,7 +273,6 @@ namespace RetinaTest
                 TestCases = { { "ab\ncde", new string[] { "a\nc", "a\nd", "a\ne", "b\nc", "b\nd", "b\ne" } } }
             });
         }
-
 
         [TestMethod]
         public void TestRandomGroup()

--- a/Retina/RetinaTest/ReplacerTest.cs
+++ b/Retina/RetinaTest/ReplacerTest.cs
@@ -227,6 +227,21 @@ namespace RetinaTest
 
             AssertProgram(new TestSuite { Sources = { @"\w+", "$;0" }, TestCases = { { "123,321,123,321", "3,2,1,0" } } });
             AssertProgram(new TestSuite { Sources = { @"\w+", "$;&" }, TestCases = { { "123,321,123,321", "3,2,1,0" } } });
+
+            // Test interaction with adjacency modifiers
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$<:&" }, TestCases = { { "123,321,123,321", "0,1,2,3" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$>:&" }, TestCases = { { "123,321,123,321", "1,2,3,4" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$[:&" }, TestCases = { { "123,321,123,321", ",0,1,2" } } });
+            AssertProgram(new TestSuite { Sources = { @"y`\w+", "$[:&" }, TestCases = { { "123,321,123,321", "3,0,1,2" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$]:&" }, TestCases = { { "123,321,123,321", "1,2,3," } } });
+            AssertProgram(new TestSuite { Sources = { @"y`\w+", "$]:&" }, TestCases = { { "123,321,123,321", "1,2,3,0" } } });
+
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$<;&" }, TestCases = { { "123,321,123,321", "4,3,2,1" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$>;&" }, TestCases = { { "123,321,123,321", "3,2,1,0" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$[;&" }, TestCases = { { "123,321,123,321", ",3,2,1" } } });
+            AssertProgram(new TestSuite { Sources = { @"y`\w+", "$[;&" }, TestCases = { { "123,321,123,321", "0,3,2,1" } } });
+            AssertProgram(new TestSuite { Sources = { @"\w+", "$];&" }, TestCases = { { "123,321,123,321", "2,1,0," } } });
+            AssertProgram(new TestSuite { Sources = { @"y`\w+", "$];&" }, TestCases = { { "123,321,123,321", "2,1,0,3" } } });
         }
 
         [TestMethod]

--- a/Retina/RetinaTest/ReplacerTest.cs
+++ b/Retina/RetinaTest/ReplacerTest.cs
@@ -245,35 +245,6 @@ namespace RetinaTest
         }
 
         [TestMethod]
-        public void TestCumulativeCaptureCount()
-        {
-            AssertProgram(new TestSuite { Sources = { "(.)+", "#$:1" }, TestCases = { { "abcd\ndef", "#4\n#7" } } });
-            AssertProgram(new TestSuite { Sources = { "(..)+", "#$:1" }, TestCases = { { "abcd\ndef", "#2\n#3f" } } });
-            AssertProgram(new TestSuite { Sources = { "()(.)*", "$:2" }, TestCases = { { "abcd\ndef", "44\n77" } } });
-            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "$:1" }, TestCases = { { "aaabbcabbb", "5c9" } } });
-            AssertProgram(new TestSuite { Sources = { "(.)+", "#$;1" }, TestCases = { { "abcd\ndef", "#7\n#3" } } });
-            AssertProgram(new TestSuite { Sources = { "(..)+", "#$;1" }, TestCases = { { "abcd\ndef", "#3\n#1f" } } });
-            AssertProgram(new TestSuite { Sources = { "()(.)*", "$;2" }, TestCases = { { "abcd\ndef", "73\n30" } } });
-            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "$;1" }, TestCases = { { "aaabbcabbb", "9c5" } } });
-
-            // Curly braces should also work:
-            AssertProgram(new TestSuite { Sources = { "(.)+", "#${:1}" }, TestCases = { { "abcd\ndef", "#4\n#7" } } });
-            AssertProgram(new TestSuite { Sources = { "()(.)*", "${:2}" }, TestCases = { { "abcd\ndef", "40\n70" } } });
-            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "${:1}${:01}${:001}" }, TestCases = { { "aaabbcabbb", "555c999" } } });
-            AssertProgram(new TestSuite { Sources = { "(?<foo>a)+(?<bar>b)+", "${:foo}${:bar}" }, TestCases = { { "aaabbcabbb", "32c45" } } });
-            AssertProgram(new TestSuite { Sources = { "(.)+", "#${;1}" }, TestCases = { { "abcd\ndef", "#7\n#3" } } });
-            AssertProgram(new TestSuite { Sources = { "()(.)*", "${;2}" }, TestCases = { { "abcd\ndef", "73\n30" } } });
-            AssertProgram(new TestSuite { Sources = { "(a)+(?<1>b)+", "${;1}${;01}${;001}" }, TestCases = { { "aaabbcabbb", "999c444" } } });
-            AssertProgram(new TestSuite { Sources = { "(?<foo>a)+(?<bar>b)+", "${;foo}${;bar}" }, TestCases = { { "aaabbcabbb", "45c13" } } });
-
-            // $# not followed by a valid group should be removed.
-            AssertProgram(new TestSuite { Sources = { "(.)+", "$:2${:2}$:$:}" }, TestCases = { { "abcd", "$:$:}" } } });
-            AssertProgram(new TestSuite { Sources = { "(?<a>.)+", "$:a${:b}$:{" }, TestCases = { { "abcd", "$:a$:{" } } });
-            AssertProgram(new TestSuite { Sources = { "(.)+", "$:2${:2}$:$:}" }, TestCases = { { "abcd", "$;$;}" } } });
-            AssertProgram(new TestSuite { Sources = { "(?<a>.)+", "$:a${:b}$:{" }, TestCases = { { "abcd", "$;a$;{" } } });
-        }
-
-        [TestMethod]
         public void TestRandomCapture()
         {
             AssertRandomProgram(new RandomTestSuite


### PR DESCRIPTION
Added `:` and `;` as a modifier for `$&` and `$0` to generate the current match index from the left or right.