### PR TITLE
Provide addititve identity when taking the sum

### DIFF
--- a/Retina/Retina/Replace/Nodes/Concatenation.cs
+++ b/Retina/Retina/Replace/Nodes/Concatenation.cs
@@ -21,7 +21,7 @@ namespace Retina.Replace.Nodes
 
         public override BigInteger GetLength(string input, List<MatchContext> matches, List<MatchContext> separators, int index)
         {
-            return Children.Select(c => c.GetLength(input, matches, separators, index)).Aggregate((cur, sum) => sum + cur);
+            return Children.Select(c => c.GetLength(input, matches, separators, index)).Aggregate(BigInteger.Zero, (cur, sum) => sum + cur);
         }
     }
 }


### PR DESCRIPTION
Commit 444e816 introduced a bug whereby `$.()` causes the program to crash because it tries to take the sum of a zero-length list without providing the additive identity.